### PR TITLE
Make MutableNode actually mutable

### DIFF
--- a/src/main/java/team02/project/graph/MutableNode.java
+++ b/src/main/java/team02/project/graph/MutableNode.java
@@ -1,16 +1,21 @@
 package team02.project.graph;
 
-import lombok.Value;
+import lombok.Data;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@Value
+@Data
 public class MutableNode implements Node {
     int id;
     int weight;
     Map<Node, Integer> incomingEdges = new HashMap<>();
     Map<Node, Integer> outgoingEdges = new HashMap<>();
+
+    public MutableNode(int id, int weight) {
+        this.id = id;
+        this.weight = weight;
+    }
 
     @Override
     public boolean equals(Object other) {


### PR DESCRIPTION
In future, we will need this to be mutable as we perform preprocessing
on the graph; the current name is confusing since the class was actually
immutable. Hopefully this confusion will be eliminated by allowing its
fields to be mutated.