### PR TITLE
Select processors in round-robin order

### DIFF
--- a/src/main/java/team02/project/algorithm/solnspace/ao/Allocation.java
+++ b/src/main/java/team02/project/algorithm/solnspace/ao/Allocation.java
@@ -20,15 +20,18 @@ public class Allocation {
      */
     private final List<Set<Node>> tasks;
 
+    private final long[] allocationBits;
+
     private final int[] loadsPerProcessor;
     private final Map<Node, Integer> processors;
     private final Map<Node, Integer> topLevelAllocated;
     private final Map<Node, Integer> bottomLevelAllocated;
     private final int estimatedCost;
 
-    private Allocation(List<Set<Node>> tasks, int[] loadsPerProcessor,  Map<Node, Integer> processors,
+    private Allocation(List<Set<Node>> tasks, long[] allocationBits, int[] loadsPerProcessor,  Map<Node, Integer> processors,
                        Map<Node, Integer> topLevelAllocated, Map<Node, Integer> bottomLevelAllocated, int estimatedCost) {
         this.tasks = tasks;
+        this.allocationBits = allocationBits;
         this.loadsPerProcessor = loadsPerProcessor;
         this.processors = processors;
         this.topLevelAllocated = topLevelAllocated;
@@ -93,7 +96,15 @@ public class Allocation {
                 queue.offer(node2);
             }
         }
-        return new Allocation(tasks, loadsPerProcessor,  processorLookup, topLevelAllocated,
+
+        long[] allocationBits = new long[ctx.getProcessorCount()];
+        for(int i = 0; i < tasks.size(); ++i) {
+            for(Node node : tasks.get(i)) {
+                allocationBits[i] |= (1 << node.getIndex());
+            }
+        }
+
+        return new Allocation(tasks, allocationBits, loadsPerProcessor,  processorLookup, topLevelAllocated,
                 bottomLevelAllocated, alloc.getEstimatedFinishTime());
     }
 
@@ -143,5 +154,9 @@ public class Allocation {
      */
     public int getEstimatedFinishTime() {
         return estimatedCost;
+    }
+
+    public long[] getAllocationBits() {
+        return allocationBits;
     }
 }

--- a/src/main/java/team02/project/algorithm/solnspace/ao/OPartialSolution.java
+++ b/src/main/java/team02/project/algorithm/solnspace/ao/OPartialSolution.java
@@ -88,14 +88,12 @@ public class OPartialSolution implements PartialSolution {
             return Collections.singleton(new AOCompleteSolution(this));
         }
 
-        Set<PartialSolution> output = expandProcessor(processor);
-
-        if(output.isEmpty()) {
-            // no tasks left on that processor, on to the next one.
-            output = expandProcessor(processor + 1);
+        int nextProcessor = (processor + 1) % context.getProcessorCount();
+        while((allocation.getAllocationBits()[nextProcessor] & orderedBits) == allocation.getAllocationBits()[nextProcessor]) {
+            nextProcessor = (nextProcessor + 1) % context.getProcessorCount();
         }
 
-        return output;
+        return expandProcessor(nextProcessor);
     }
 
     /**


### PR DESCRIPTION
Possible that performance will be better due to improved heuristics. Needs testing for performance and validity, although it looks like output is optimal with `all10nodes`.